### PR TITLE
Update liip/imagine-bundle to v2.0 as dev-master is no longer exists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/symfony": ">=2.5|~3.0",
         "sensio/framework-extra-bundle": "~3.0",
         "vich/uploader-bundle": "~0|~1",
-        "liip/imagine-bundle": "dev-master"
+        "liip/imagine-bundle": "~2.0"
     },
 
     "config": {


### PR DESCRIPTION
It seems that `master` branch was removed from https://github.com/liip/LiipImagineBundle repo in favor of 2.0